### PR TITLE
feat: shared author info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Build
 /local.properties
-/.kotlin/
-/.gradle/
+**/.kotlin/
+**/.gradle/
 **/build/
 **/.cxx/
 **/.externalNativeBuild/

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    compileOnly(libs.aliucord.gradle)
+}
+
+gradlePlugin {
+    plugins {
+        create("aliucord-plugins-repo") {
+            id = "com.aliucord.plugins-repo"
+            implementationClass = "com.aliucord.gradle.repo.RepoPlugin"
+        }
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,18 @@
+@file:Suppress("UnstableApiUsage")
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            name = "aliucord"
+            url = uri("https://maven.aliucord.com/releases")
+        }
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/com/aliucord/gradle/repo/Authors.kt
+++ b/build-logic/src/main/kotlin/com/aliucord/gradle/repo/Authors.kt
@@ -1,0 +1,55 @@
+package com.aliucord.gradle.repo
+
+import com.aliucord.gradle.AliucordExtension
+
+/**
+ * A list of all currently known authors, used in the plugin buildscripts
+ * to specify plugin authors. Add yourself to this list rather than duplicating
+ * your author information in each separate plugin.
+ *
+ * Entries are not required to use standard Kotlin naming conventions.
+ *
+ * Example usage from a plugin's `build.gradle.kts`:
+ * ```kotlin
+ * import com.aliucord.gradle.Authors
+ * import com.aliucord.gradle.author
+ *
+ * // ...
+ *
+ * aliucord {
+ *     author(Authors.xyz)
+ *
+ *     // ...
+ * }
+ * ```
+ */
+@Suppress("SpellCheckingInspection", "unused", "RedundantSuppression")
+object Authors {
+    val Aliucord = Author(name = "Aliucord")
+}
+
+/**
+ * Represents a plugin author.
+ *
+ * @param name      The user-facing name to display
+ * @param id        The Discord ID of the author, optional.
+ *                  This also will allow Aliucord to show a badge on your profile if the plugin is installed.
+ * @param hyperlink Whether to hyperlink the Discord profile specified by [id].
+ *                  Set this to false if you don't want to be spammed for support.
+ */
+data class Author(
+    val name: String,
+    val id: Long = 0L,
+    val hyperlink: Boolean = true,
+)
+
+/**
+ * Specifies an already-known author of this plugin.
+ */
+fun AliucordExtension.author(author: Author) {
+    author(
+        name = author.name,
+        id = author.id,
+        hyperlink = author.hyperlink,
+    )
+}

--- a/build-logic/src/main/kotlin/com/aliucord/gradle/repo/Authors.kt
+++ b/build-logic/src/main/kotlin/com/aliucord/gradle/repo/Authors.kt
@@ -14,7 +14,12 @@ import com.aliucord.gradle.AliucordExtension
  * import com.aliucord.gradle.Authors
  * import com.aliucord.gradle.author
  *
- * // ...
+ * plugins {
+ *     id("com.aliucord.plugins-repo")
+ * }
+ *
+ * version = "..."
+ * description = "..."
  *
  * aliucord {
  *     author(Authors.xyz)

--- a/build-logic/src/main/kotlin/com/aliucord/gradle/repo/RepoPlugin.kt
+++ b/build-logic/src/main/kotlin/com/aliucord/gradle/repo/RepoPlugin.kt
@@ -1,0 +1,13 @@
+package com.aliucord.gradle.repo
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * A dummy Gradle plugin applied to Aliucord plugin buildscripts.
+ * ID: `com.aliucord.plugins-repo`
+ */
+@Suppress("unused")
+class RepoPlugin : Plugin<Project> {
+    override fun apply(target: Project) {}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ ktlint-plugin = "14.2.0"
 
 [libraries]
 aliucord = { module = "com.aliucord:Aliucord", version.ref = "aliucord" }
+aliucord-gradle = { module = "com.aliucord:gradle", version.ref = "aliucord-gradle" }
 discord = { module = "com.discord:discord", version.ref = "discord" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 

--- a/plugins/Template/build.gradle.kts
+++ b/plugins/Template/build.gradle.kts
@@ -1,7 +1,16 @@
+import com.aliucord.gradle.repo.Authors
+import com.aliucord.gradle.repo.author
+
+plugins {
+    id("com.aliucord.plugins-repo")
+}
+
 version = "1.0.0"
 description = "Template plugin"
 
 aliucord {
+    author(Authors.Aliucord)
+
     changelog.set(
         """
         # 1.0.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google()
         gradlePluginPortal()


### PR DESCRIPTION
Adds a Gradle build project to apply a dummy Gradle plugin to all plugin projects, such that we can declare author info once and re-use it within from all plugin buildscripts.

This can still be up for debate, I'm not sure as to how to best approach this. I fought with Gradle trying to get this to work for hours, and this was the most sensible way I got to work. (`buildSrc` had issues with transitive dependencies, convention plugin scripts don't get added to the classpath, etc.)